### PR TITLE
[feat] 전세권설정 정보 추출 구현

### DIFF
--- a/backend/src/main/java/org/scoula/register/controller/TabulaController.java
+++ b/backend/src/main/java/org/scoula/register/controller/TabulaController.java
@@ -22,6 +22,7 @@ public class TabulaController {
     private final AuctionServiceImpl auctionServiceImpl;
     private final ProvisionalRegistrationServiceImpl provisionalRegistrationServiceImpl;
     private final InjunctionServiceImpl injunctionServiceImpl;
+    private final JeonseRightServiceImpl jeonseRightServiceImpl;
 
     @PostMapping
     @ResponseBody
@@ -107,6 +108,19 @@ public class TabulaController {
             List<List<String>> table = tabulaService.extractTable(file.getInputStream());
             List<InjunctionDTO> injunction = injunctionServiceImpl.extractInjunctions(table);
             return ResponseEntity.ok(injunction);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @PostMapping("/jeonse-right")
+    @ResponseBody
+    public ResponseEntity<List<JeonseRightDTO>> extractJeonseRights(@RequestParam("file") MultipartFile file) {
+        try {
+            List<List<String>> table = tabulaService.extractTable(file.getInputStream());
+            List<JeonseRightDTO> jeonseRight = jeonseRightServiceImpl.extractJeonseRightInfos(table);
+            return ResponseEntity.ok(jeonseRight);
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.internalServerError().build();

--- a/backend/src/main/java/org/scoula/register/domain/dto/JeonseRightDTO.java
+++ b/backend/src/main/java/org/scoula/register/domain/dto/JeonseRightDTO.java
@@ -1,0 +1,16 @@
+package org.scoula.register.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class JeonseRightDTO {
+    private String rank;
+    private String registrationPurpose;
+    private String registrationCause;
+    private String deposit;
+    private String mortgagor;
+}

--- a/backend/src/main/java/org/scoula/register/service/JeonseRightService.java
+++ b/backend/src/main/java/org/scoula/register/service/JeonseRightService.java
@@ -1,0 +1,9 @@
+package org.scoula.register.service;
+
+import org.scoula.register.domain.dto.JeonseRightDTO;
+
+import java.util.List;
+
+public interface JeonseRightService {
+    List<JeonseRightDTO> extractJeonseRightInfos(List<List<String>> tableData);
+}

--- a/backend/src/main/java/org/scoula/register/service/JeonseRightServiceImpl.java
+++ b/backend/src/main/java/org/scoula/register/service/JeonseRightServiceImpl.java
@@ -1,0 +1,66 @@
+package org.scoula.register.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.scoula.register.domain.dto.JeonseRightDTO;
+import org.scoula.register.util.RegisterUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class JeonseRightServiceImpl implements JeonseRightService {
+    @Override
+    public List<JeonseRightDTO> extractJeonseRightInfos(List<List<String>> tableData) {
+        List<JeonseRightDTO> jeonseRights = new ArrayList<>();
+        List<String> canceledRanks = new ArrayList<>();
+        List<List<String>> mergedTable = RegisterUtils.mergeRowsWithCanceled(tableData);
+
+        // 말소된 등기 찾기
+        for (List<String> row : mergedTable) {
+            if (row.size() < 2) continue;
+
+            String registrationPurpose = RegisterUtils.normalizeText(row.get(1));
+
+            if (registrationPurpose != null && registrationPurpose.contains("전세권설정") && registrationPurpose.contains("말소")) {
+//                System.out.println("읽어온 문장: " + registrationPurpose);
+                List<String> canceled = RegisterUtils.extractCanceledRanks(registrationPurpose);  // 말소된 번호
+                canceledRanks.addAll(canceled);
+            }
+        }
+
+        // 본 등기에서 말소된 순번은 제외하고 처리
+        for (List<String> row : mergedTable) {
+            if (row.size() < 5) continue;
+
+            String rank = row.get(0).trim();    // 순위번호
+            String registrationPurpose = RegisterUtils.normalizeText(row.get(1));    // 등기목적
+
+            if (registrationPurpose != null &&
+                    registrationPurpose.contains("전세권설정") &&
+                    !registrationPurpose.contains("말소") &&
+                    !canceledRanks.contains(rank)) {
+
+                String registrationCause = RegisterUtils.trimAfterParenthesis(row.get(3));  // 등기 원인
+                String etc = row.get(4);                // 권리자 및 기타사항
+
+                String deposit = RegisterUtils.extractAmountByKeywords(etc);
+                String mortgagor = RegisterUtils.extractCreditorOrRightHolder(etc);
+
+                JeonseRightDTO info = new JeonseRightDTO();
+                info.setRank(rank);
+                info.setRegistrationPurpose(registrationPurpose);
+                info.setRegistrationCause(registrationCause);
+                info.setDeposit(deposit);
+                info.setMortgagor(mortgagor);
+
+                jeonseRights.add(info);
+            }
+        }
+
+        return jeonseRights;
+    }
+}

--- a/frontend/src/pages/SafetyDiagnosis.vue
+++ b/frontend/src/pages/SafetyDiagnosis.vue
@@ -9,6 +9,7 @@ const provisionalSeizureInfos = ref([]);
 const auctionInfos = ref([]);
 const provisionalRegistrationInfos = ref([]);
 const injunctionInfos = ref([]);
+const jeonseRightInfos = ref([]);
 
 function handleFileChange(event) {
   selectedFile.value = event.target.files[0];
@@ -112,7 +113,7 @@ async function uploadFile() {
       console.error('가등기 정보 추출 실패');
     }
 
-    // 가등기 정보 받아오기
+    // 가처분 정보 받아오기
     const injunctionRes = await fetch(
       'http://localhost:8080/safety-check/injunction',
       {
@@ -125,6 +126,21 @@ async function uploadFile() {
       injunctionInfos.value = await injunctionRes.json();
     } else {
       console.error('가처분 정보 추출 실패');
+    }
+
+    // 전세권설정 정보 받아오기
+    const jeonseRightRes = await fetch(
+      'http://localhost:8080/safety-check/jeonse-right',
+      {
+        method: 'POST',
+        body: formData,
+      }
+    );
+
+    if (jeonseRightRes.ok) {
+      jeonseRightInfos.value = await jeonseRightRes.json();
+    } else {
+      console.error('전세권설정 정보 추출 실패');
     }
   } catch (error) {
     console.error('업로드 중 오류 발생:', error);
@@ -299,6 +315,31 @@ async function uploadFile() {
           <td class="border px-2 py-1">{{ item.registrationPurpose }}</td>
           <td class="border px-2 py-1">{{ item.registrationCause }}</td>
           <td class="border px-2 py-1">{{ item.creditor }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- 전세권설정 정보 표 -->
+  <div v-if="jeonseRightInfos.length">
+    <h3 class="text-lg font-semibold mt-6 mb-2">전세권설정 정보</h3>
+    <table class="border border-gray-300 w-full">
+      <thead>
+        <tr>
+          <th class="border px-2 py-1">순위</th>
+          <th class="border px-2 py-1">등기목적</th>
+          <th class="border px-2 py-1">등기원인</th>
+          <th class="border px-2 py-1">전세금</th>
+          <th class="border px-2 py-1">전세권자</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(item, index) in jeonseRightInfos" :key="index">
+          <td class="border px-2 py-1">{{ item.rank }}</td>
+          <td class="border px-2 py-1">{{ item.registrationPurpose }}</td>
+          <td class="border px-2 py-1">{{ item.registrationCause }}</td>
+          <td class="border px-2 py-1">{{ item.deposit }}</td>
+          <td class="border px-2 py-1">{{ item.mortgagor }}</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

close #33 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

전세권설정 정보 추출
- 순위번호
- 등기목적
- 등기원인
- 전세금
- 전세권자

경매에서 말소된 부분 처리가 빠져서 추가했습니다.

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

전세권 설정 정보는 실제 기재된 등기부등본을 찾기 힘들어서 테스트용 pdf 작성한 뒤에 테스트 완료했습니다.

## #️⃣ 변경 사항 체크리스트

- [X] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [X] 코드 컨벤션에 따라 코드를 작성했나요?
- [X] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.
<img width="469" height="102" alt="전세권설정" src="https://github.com/user-attachments/assets/e160468d-58a6-450e-93f6-bb88fee70f43" />

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
