### PR TITLE
[feat] 판정기준 모달창 구현, 테스트 페이지 생성, index.js 연결

### DIFF
--- a/frontend/src/components/DiagnosisGradeInfoModal.vue
+++ b/frontend/src/components/DiagnosisGradeInfoModal.vue
@@ -1,0 +1,114 @@
+<script setup>
+defineProps({
+  show: Boolean, // 부모 컴포넌트로부터 표시 여부
+});
+
+const gradeList = [
+  {
+    title: '안전 등급',
+    colorClass: 'text-primary',
+    items: [
+      '등기분석: 권리 침해 사항이 하나도 없는 경우',
+      '전세가율: -5% 이하',
+      '체크리스트: 모두 체크',
+    ],
+  },
+  {
+    title: '보통 등급',
+    colorClass: 'text-success',
+    items: [
+      '등기분석: 최근 2년 이내에 권리침해 사항이 있는 경우',
+      '전세가율: +0~4%',
+      '체크리스트: 입주 전 수리에 대해 확인, 임차 주택의 사용/관리 수선 확인 미체크 시',
+    ],
+  },
+  {
+    title: '주의 등급',
+    colorClass: 'text-warning',
+    items: [
+      '등기분석: 최근 1년 이내에 권리침해 사항이 있는 경우',
+      '전세가율: 해당 지역 평균보다 +5% 이상',
+      '체크리스트: 불리한 특약 확인 미체크 시',
+    ],
+  },
+  {
+    title: '위험 등급',
+    colorClass: 'text-danger',
+    items: [
+      '등기분석: 현재 기준 권리침해 사항이 하나라도 있는 경우',
+      '전세가율: 해당지역 평균보다 +10% 이상',
+      '체크리스트: 임대인의 미납 세금 확인, 확정일자, 등기부등본상 소유주 일치 여부, 선순위 세입자 항목, 주소일치 여부, 전입신고 가능 여부 중 하나라도 미체크 시',
+    ],
+  },
+  {
+    title: '판단 보류 등급',
+    colorClass: 'text-muted',
+    items: [
+      '등기분석: 최근 2년 이내에 권리침해 사항이 있는 경우',
+      '전세가율: +0~4%',
+      '체크리스트: 입주 전 수리에 대해 확인, 임차 주택의 사용/관리 수선 확인 미체크 시',
+    ],
+  },
+];
+</script>
+
+<template>
+  <div
+    v-if="show"
+    class="DiagnosisModalPage d-flex justify-content-center align-items-center bg-dark bg-opacity-50 position-fixed top-0 start-0 w-100"
+  >
+    <div
+      class="diagnosis-box bg-white rounded-4 shadow-sm p-4 d-flex flex-column"
+    >
+      <h1 class="fs-4 fw-bold text-center mb-3 my-2">진단 등급 판정 기준</h1>
+
+      <div class="diagnosis-content flex-grow-1 overflow-auto px-1 py-2">
+        <div
+          v-for="(grade, index) in gradeList"
+          :key="index"
+          class="mb-4 text-start"
+        >
+          <div :class="[grade.colorClass, 'fw-bold', 'mb-2']">
+            {{ grade.title }}
+          </div>
+          <div class="bg-light rounded-3 p-3">
+            <div v-for="(item, i) in grade.items" :key="i" class="mb-1">
+              <p class="mb-1">{{ item }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="text-center mt-3">
+        <button
+          class="btn btn-primary px-4 py-2 rounded-3"
+          @click="$emit('close')"
+        >
+          확인 완료
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.DiagnosisModalPage {
+  overflow: hidden;
+  height: 100dvh;
+  z-index: 1050;
+}
+
+.diagnosis-box {
+  width: 95%;
+  max-width: 720px;
+  height: calc(100dvh - 130px);
+}
+
+@media (max-width: 576px) {
+  .diagnosis-box {
+    width: 100%;
+    height: 95vh;
+    border-radius: 0;
+  }
+}
+</style>

--- a/frontend/src/pages/FinalReportPage.vue
+++ b/frontend/src/pages/FinalReportPage.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { ref } from 'vue';
+import DiagnosisGradeInfoModal from '@/components/DiagnosisGradeInfoModal.vue';
+
+const showModal = ref(false);
+
+const openModal = () => {
+  showModal.value = true;
+};
+
+const closeModal = () => {
+  showModal.value = false;
+};
+</script>
+
+<template>
+  <div class="FinalReportPage container py-5 text-center">
+    <p class="text-muted">
+      모든 등급은
+      <span
+        class="text-primary text-decoration-underline"
+        role="button"
+        style="cursor: pointer"
+        @click="openModal"
+        >판정기준</span
+      >에 의해 설정된 등급입니다.
+    </p>
+    <DiagnosisGradeInfoModal :show="showModal" @close="closeModal" />
+  </div>
+</template>
+
+<style scoped>
+/* .FinalReportPage {
+} */
+</style>

--- a/frontend/src/pages/ReferenceGuideBook.vue
+++ b/frontend/src/pages/ReferenceGuideBook.vue
@@ -1,8 +1,0 @@
-<script setup>
-import Header from '../components/Header.vue'
-</script>
-
-<template>
-
-  <h1>참고 가이드북 페이지</h1>
-</template>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -9,6 +9,7 @@ import GuidebookPage from '@/pages/GuidebookPage.vue';
 import MyPage from '@/pages/MyPage.vue';
 import NonDiagnosis from '@/pages/checklist/ForNoneDiagnosis.vue';
 import CheckList from '@/pages/checklist/Checklist.vue';
+import FinalReportPage from '@/pages/FinalReportPage.vue';
 
 // 카테고리 및 용어 관련 추가
 import CategoryAll from '@/pages/category/CategoryAll.vue';
@@ -35,7 +36,7 @@ const routes = [
   },
   {
     path: '/reference-guidebook',
-    name: 'reference-guidebook',
+    name: 'guidebookPage',
     component: GuidebookPage,
   },
   { path: '/glossary', name: 'glossary', component: GlossaryBook },
@@ -110,6 +111,11 @@ const routes = [
     name: 'SpecialContractsRecommendation',
     component: () =>
       import('@/pages/special-contracts/SpecialContractsRecommendation.vue'),
+  },
+  {
+    path: '/final-report',
+    name: 'finalReportPage',
+    component: FinalReportPage,
   },
 ];
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #46 

## #️⃣ 작업 내용
- [x] components - DiagnosisGradeInfoModal.vue 작업
    - 등급 리스트 반복 렌더링 (v-for)
    - 반응형 스타일링
    - 콘텐츠가 길어지면 내부 스크롤 되도록 스타일링
- [x] pages - FinalReportPage.vue 모달창 연동 및 확인을 위한 기본적인 테스트용 코드만 간단히 구현
- [x] router-index.js에 FinalReportPage 추가

## #️⃣ 스크린샷 (선택)

<img width="394" height="57" alt="Image" src="https://github.com/user-attachments/assets/16bf1f99-2a5f-49ac-9de4-8b71db2e22dc" />

<img width="986" height="870" alt="Image" src="https://github.com/user-attachments/assets/0010308f-58ea-4fd5-90ec-bd9b1530c461" />
