### PR TITLE
[feat] 최종리포트 전세가율 그래프 구현, api 로직 분리

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.10.0",
         "bootstrap": "^5.3.7",
         "chart.js": "^4.5.0",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "moment": "^2.30.1",
         "pinia": "^3.0.1",
         "vue": "^3.5.13",
@@ -2042,6 +2043,15 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/color-convert": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "axios": "^1.10.0",
     "bootstrap": "^5.3.7",
     "chart.js": "^4.5.0",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "moment": "^2.30.1",
     "pinia": "^3.0.1",
     "vue": "^3.5.13",

--- a/frontend/src/api/finalReport.js
+++ b/frontend/src/api/finalReport.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const getFinalReport = async (reportId) => {
+  const res = await axios.get(`/api/final-report/${reportId}`);
+  return res.data;
+};

--- a/frontend/src/components/final-report/FinalChecklist.vue
+++ b/frontend/src/components/final-report/FinalChecklist.vue
@@ -7,6 +7,6 @@
 </template>
 
 <style scoped>
-.FinalChecklist {
-}
+/* .FinalChecklist {
+} */
 </style>

--- a/frontend/src/components/final-report/FinalGrade.vue
+++ b/frontend/src/components/final-report/FinalGrade.vue
@@ -12,31 +12,11 @@ const gradeColor = {
   판단보류: '#FBC02D',
 };
 
-const registry = ref('');
-const jeonse = ref('');
-const checklist = ref('');
-
-// 테스트용 리포트 id (추후 삭제 예정)
-const reportId = 1;
-
-const fetchGrades = async () => {
-  try {
-    // 백엔드 작업하고 주석 해제에서 실제 데이터 연동 예정
-    // const {data} = await axios.get(`/api/final-report/${reportId}`);
-    // registry.value = data.registryRating;
-    // jeonse.value = data.jeonseRatioRating;
-    // checklist.value = data.checklistRating;
-
-    // 테스트용 데이터
-    registry.value = '보통';
-    jeonse.value = '판단보류';
-    checklist.value = '안전';
-  } catch {
-    console.error('등급 데이터 가져오기 실패', err);
-  }
-};
-
-onMounted(fetchGrades);
+const props = defineProps({
+  registry: { type: String, default: '' },
+  jeonse: { type: String, default: '' },
+  checklist: { type: String, default: '' },
+});
 </script>
 
 <template>
@@ -45,19 +25,19 @@ onMounted(fetchGrades);
       <DonutChart
         v-if="registry"
         :grade="registry"
-        :color="gradeColor[registry]"
+        :color="gradeColor[registry] || '#ddd'"
         label="등기부등본"
       />
       <DonutChart
         v-if="jeonse"
         :grade="jeonse"
-        :color="gradeColor[jeonse]"
+        :color="gradeColor[jeonse] || '#ddd'"
         label="전세가율"
       />
       <DonutChart
         v-if="checklist"
         :grade="checklist"
-        :color="gradeColor[checklist]"
+        :color="gradeColor[checklist] || '#ddd'"
         label="체크리스트"
       />
     </div>
@@ -69,19 +49,21 @@ onMounted(fetchGrades);
   display: flex;
   justify-content: center;
   padding: 1rem;
+  margin-bottom: 3rem;
 }
 
 .donut-wrap {
   display: flex;
   justify-content: center;
-  gap: 8rem;
+  gap: 10rem;
   flex-wrap: wrap;
 }
 
 @media (max-width: 768px) {
   .donut-wrap {
-    column-gap: 4rem;
-    row-gap: 1.5rem;
+    gap: 12rem;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
   }
 }
 </style>

--- a/frontend/src/components/final-report/FinalJeonse.vue
+++ b/frontend/src/components/final-report/FinalJeonse.vue
@@ -1,18 +1,17 @@
 <script setup>
 import BarChart from './charts/BarChart.vue';
 
-const mockData = {
-  jeonseRatio: 77.8,
-  regionAvgJeonseRatio: 75.0,
-};
+const props = defineProps({
+  jeonseRatio: { type: Number, default: 0 },
+  regionAvgJeonseRatio: { type: Number, default: 0 },
+});
 </script>
 
 <template>
   <div class="FinalJeonse">
-    <!-- <h2>전세가율 컴포넌트</h2> -->
     <BarChart
-      :jeonseRatio="mockData.jeonseRatio"
-      :regionAvgJeonseRatio="mockData.regionAvgJeonseRatio"
+      :jeonseRatio="jeonseRatio"
+      :regionAvgJeonseRatio="regionAvgJeonseRatio"
     />
   </div>
 </template>

--- a/frontend/src/components/final-report/FinalJeonse.vue
+++ b/frontend/src/components/final-report/FinalJeonse.vue
@@ -1,12 +1,23 @@
-<script setup></script>
+<script setup>
+import BarChart from './charts/BarChart.vue';
+
+const mockData = {
+  jeonseRatio: 77.8,
+  regionAvgJeonseRatio: 75.0,
+};
+</script>
 
 <template>
   <div class="FinalJeonse">
-    <h2>전세가율 컴포넌트</h2>
+    <!-- <h2>전세가율 컴포넌트</h2> -->
+    <BarChart
+      :jeonseRatio="mockData.jeonseRatio"
+      :regionAvgJeonseRatio="mockData.regionAvgJeonseRatio"
+    />
   </div>
 </template>
 
 <style scoped>
-.FinalJeonse {
-}
+/* .FinalJeonse {
+} */
 </style>

--- a/frontend/src/components/final-report/charts/BarChart.vue
+++ b/frontend/src/components/final-report/charts/BarChart.vue
@@ -1,10 +1,83 @@
-<script setup></script>
+<script setup>
+import { Bar } from 'vue-chartjs';
+import { Chart, BarElement, CategoryScale, LinearScale } from 'chart.js';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
+import plugin from 'chartjs-plugin-datalabels';
+
+// Chart.js 등록
+Chart.register(
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  ChartDataLabels
+  // Tooltip
+);
+
+const props = defineProps({
+  jeonseRatio: Number,
+  regionAvgJeonseRatio: Number,
+});
+
+const chartData = {
+  // x축
+  labels: ['지역 평균 전세가율', '예상 전세가율'],
+  datasets: [
+    {
+      // y축
+      data: [props.regionAvgJeonseRatio, props.jeonseRatio],
+      backgroundColor: ['#007bff', '#fec43f'],
+      borderRadius: {
+        topLeft: 10,
+        topRight: 10,
+        bottomLeft: 0,
+        bottomRight: 0,
+      },
+      borderSkipped: false,
+      barThickness: 50,
+    },
+  ],
+};
+
+const chartOptions = {
+  responsive: true, // 반응형 스타일링
+
+  plugins: {
+    datalabels: {
+      anchor: 'end',
+      align: 'end',
+      color: '#fff',
+      backgroundColor: '#000',
+      font: { weight: 'bold', size: 12 },
+      padding: 6,
+      formatter: (v) => `${v.toFixed(1)}%`,
+    },
+  },
+  scales: {
+    y: {
+      display: false,
+      beginAtZero: true,
+      max: 100,
+    },
+    x: {
+      grid: { display: false }, // x축 선 제거
+      ticks: {
+        font: { size: 14, weight: 'bold' },
+        color: '#000',
+      },
+    },
+  },
+};
+</script>
 
 <template>
-  <div class="BarChart"></div>
+  <div class="BarChart">
+    <Bar :data="chartData" :options="chartOptions" />
+  </div>
 </template>
 
 <style scoped>
-/* .BarChart {
-} */
+.BarChart {
+  max-width: 100%;
+  margin: 0 auto;
+}
 </style>

--- a/frontend/src/components/final-report/charts/BarChart.vue
+++ b/frontend/src/components/final-report/charts/BarChart.vue
@@ -2,20 +2,13 @@
 import { Bar } from 'vue-chartjs';
 import { Chart, BarElement, CategoryScale, LinearScale } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
-import plugin from 'chartjs-plugin-datalabels';
 
 // Chart.js 등록
-Chart.register(
-  BarElement,
-  CategoryScale,
-  LinearScale,
-  ChartDataLabels
-  // Tooltip
-);
+Chart.register(BarElement, CategoryScale, LinearScale, ChartDataLabels);
 
 const props = defineProps({
-  jeonseRatio: Number,
-  regionAvgJeonseRatio: Number,
+  jeonseRatio: { type: Number, default: 0 },
+  regionAvgJeonseRatio: { type: Number, default: 0 },
 });
 
 const chartData = {
@@ -24,7 +17,7 @@ const chartData = {
   datasets: [
     {
       // y축
-      data: [props.regionAvgJeonseRatio, props.jeonseRatio],
+      data: [props.regionAvgJeonseRatio || 0, props.jeonseRatio || 0],
       backgroundColor: ['#007bff', '#fec43f'],
       borderRadius: {
         topLeft: 10,
@@ -77,7 +70,7 @@ const chartOptions = {
 
 <style scoped>
 .BarChart {
-  max-width: 100%;
+  width: 60vw;
   margin: 0 auto;
 }
 </style>

--- a/frontend/src/components/final-report/charts/DonutChart.vue
+++ b/frontend/src/components/final-report/charts/DonutChart.vue
@@ -25,7 +25,9 @@ const chartData = {
 const chartOptions = {
   plugins: {
     legend: { display: false },
-    tooltip: { enabled: false },
+    datalabels: {
+      display: false,
+    },
   },
 };
 </script>

--- a/frontend/src/components/final-report/charts/DonutChart.vue
+++ b/frontend/src/components/final-report/charts/DonutChart.vue
@@ -1,44 +1,62 @@
 <script setup>
-import { Chart, ArcElement, plugins } from 'chart.js';
+import { Chart, ArcElement } from 'chart.js';
 import { Doughnut } from 'vue-chartjs';
+import { ref, watch } from 'vue';
 
 Chart.register(ArcElement);
 
 const props = defineProps({
-  grade: String,
-  color: String,
-  label: String,
+  grade: { type: String, default: '' },
+  color: { type: String, default: '#ddd' },
+  label: { type: String, default: '' },
 });
 
-const chartData = {
-  labels: [],
-  datasets: [
-    {
-      data: [100],
-      backgroundColor: [props.color],
-      borderWidth: 0,
-      cutout: '90%',
-    },
-  ],
-};
+const chartData = ref(null);
+const chartOptions = ref(null);
 
-const chartOptions = {
-  plugins: {
-    legend: { display: false },
-    datalabels: {
-      display: false,
-    },
+watch(
+  () => [props.grade, props.color],
+  () => {
+    if (!props.grade || !props.color) {
+      chartData.value = null;
+      chartOptions.value = null;
+      return;
+    }
+
+    chartData.value = {
+      labels: [],
+      datasets: [
+        {
+          data: [100],
+          backgroundColor: [props.color],
+          borderWidth: 0,
+          cutout: '90%',
+        },
+      ],
+    };
+
+    chartOptions.value = {
+      responsive: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: { enabled: false },
+        datalabels: { display: false },
+      },
+    };
   },
-};
+  { immediate: true }
+);
 </script>
 
 <template>
-  <div class="DonutChart">
-    <Doughnut :data="chartData" :options="chartOptions" />
-    <div class="donut-center-text" :style="{ color: props.color }">
-      {{ grade }}
+  <div class="DonutChart" v-if="chartData && chartOptions">
+    <div class="canvas-container">
+      <Doughnut :data="chartData" :options="chartOptions" />
+      <div class="donut-center-text" :style="{ color: props.color }">
+        {{ props.grade }}
+      </div>
     </div>
-    <div class="donut-label">{{ label }}</div>
+    <div class="donut-label">{{ props.label }}</div>
   </div>
 </template>
 
@@ -47,15 +65,16 @@ const chartOptions = {
   position: relative;
   width: 200px;
   height: 200px;
-  margin: 0 auto;
+  margin: 0 auto 2rem auto;
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 2rem;
+  gap: 2rem;
 }
+
 .donut-center-text {
   position: absolute;
-  top: 50%;
+  top: 70%;
   left: 50%;
   transform: translate(-50%, -50%);
   font-size: 1.5rem;
@@ -65,7 +84,7 @@ const chartOptions = {
 .donut-label {
   text-align: center;
   margin-top: 0.75rem;
-  font-size: 1.3rem;
+  font-size: 1.6rem;
   font-weight: 700;
   color: #000;
 }

--- a/frontend/src/pages/FinalReportPage.vue
+++ b/frontend/src/pages/FinalReportPage.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import DiagnosisGradeInfoModal from '@/components/final-report/DiagnosisGradeInfoModal.vue';
 import FinalGrade from '@/components/final-report/FinalGrade.vue';
 import FinalJeonse from '@/components/final-report/FinalJeonse.vue';
 import FinalRegistry from '@/components/final-report/FinalRegistry.vue';
 import FinalChecklist from '@/components/final-report/FinalChecklist.vue';
 import { useNavigation } from '@/composables/final-report/useNavigation';
+import { getFinalReport } from '@/api/finalReport';
 
 const showModal = ref(false);
 
@@ -18,6 +19,29 @@ const closeModal = () => {
 };
 
 const { goToHome, goToMyPage } = useNavigation();
+
+// 임시 목 데이터
+const reportId = 1;
+const reportData = ref({
+  registryRating: '보통',
+  jeonseRatioRating: '판단보류',
+  checklistRating: '안전',
+  jeonseRatio: 77.8,
+  regionAvgJeonseRatio: 75.0,
+});
+
+// reportData.value = null;
+// onMounted(async () => {
+//   const res = await getFinalReport(reportId);
+//   // 안전하게 받아온 데이터가 없으면 기본값 할당
+//   reportData.value = {
+//     registryRating: res?.registryRating ?? '',
+//     jeonseRatioRating: res?.jeonseRatioRating ?? '',
+//     checklistRating: res?.checklistRating ?? '',
+//     jeonseRatio: res?.jeonseRatio ?? 0,
+//     regionAvgJeonseRatio: res?.regionAvgJeonseRatio ?? 0,
+//   };
+// });
 </script>
 
 <template>
@@ -34,17 +58,50 @@ const { goToHome, goToMyPage } = useNavigation();
       >에 의해 설정된 등급입니다.
     </p>
     <DiagnosisGradeInfoModal :show="showModal" @close="closeModal" />
-    <FinalGrade />
+    <!-- v-if로 reportData 존재 확인 후 렌더링하여 undefined 방지 -->
+
+    <!-- 등급 -->
+    <div class="final-grade-wrap" style="margin-bottom: 10rem">
+      <FinalGrade
+        v-if="reportData"
+        :registry="reportData.registryRating"
+        :jeonse="reportData.jeonseRatioRating"
+        :checklist="reportData.checklistRating"
+      />
+    </div>
+
     <hr class="my-4 border-top border-secondary-subtle w-75 mx-auto" />
-    <h2>username님의 전세가율을 분석했어요.</h2>
-    <FinalJeonse />
+
+    <!-- 전세가율 -->
+    <h2 class="final-jeonse-wrap mt-5 mb-4">
+      username님의 전세가율을 분석했어요.
+    </h2>
+    <div style="margin-bottom: 5rem">
+      <FinalJeonse
+        v-if="reportData"
+        :jeonseRatio="reportData.jeonseRatio"
+        :regionAvgJeonseRatio="reportData.regionAvgJeonseRatio"
+      />
+    </div>
+
     <hr class="my-4 border-top border-secondary-subtle w-75 mx-auto" />
-    <h2>username님의 등기부등본을 분석했어요.</h2>
-    <FinalRegistry />
+
+    <!-- 등기부등본 -->
+    <h2 class="final-registry-wrap mt-5 mb-4">
+      username님의 등기부등본을 분석했어요.
+    </h2>
+    <div style="margin-bottom: 5rem">
+      <FinalRegistry />
+    </div>
+
     <hr class="my-4 border-top border-secondary-subtle w-75 mx-auto" />
-    <h2>username님이 체크하지 않은 항목이에요.</h2>
-    <p>향후 불이익을 방지하려면 지금 확인하는 것이 좋아요.</p>
-    <FinalChecklist />
+
+    <!-- 체크리스트 -->
+    <h2 class="mt-5 mb-3">username님이 체크하지 않은 항목이에요.</h2>
+    <p class="mb-4">향후 불이익을 방지하려면 지금 확인하는 것이 좋아요.</p>
+    <div class="final-checklist-wrap" style="margin: 6rem 0">
+      <FinalChecklist />
+    </div>
     <div class="final-btn-wrap d-flex justify-content-center gap-5">
       <button
         class="btn btn-primary px-4 py-2 rounded-3 background-main"
@@ -63,8 +120,9 @@ const { goToHome, goToMyPage } = useNavigation();
 </template>
 
 <style scoped>
-/* .FinalReportPage {
-} */
+.FinalReportPage {
+  margin-bottom: 5rem;
+}
 
 .background-main {
   background: #1a80e5;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #78 

## #️⃣ 작업 내용

FinalReportPage.vue
- [x] API 통신을 getFinalReport(reportId)로 분리하여 onMounted 시 데이터 fetch
- [x] reportData 상태값을 모든 시각화 컴포넌트에 props로 전달
- [x] 전세가율 하단 여백 및 hr 겹침 이슈 수정

api/finalReport.js
- [x] getFinalReport(reportId) 함수 구현

FinalGrade.vue
- [x] registry, jeonse, checklist 등급을 받아 각각 DonutChart로 시각화

FinalJeonse.vue
- [x] jeonseRatio, regionAvgJeonseRatio props 수신
- [x] BarChart.vue에 전달할 데이터 구성 및 props 연동

BarChart.vue
- [x] Chart.js 기반 막대 차트 구현 및 스타일링
- [x] chart.js-plugin-datalabels로 데이터 레이블 표시
- [x] 막대 간 간격 조정

DonutChart.vue
- [x] API 분리에 따른 목 데이터 제거
- [x] props 기반 렌더링 구조 정리
- [x] 스타일링 개선 (중앙 텍스트 정렬, 색상 매핑, 반응형 여백 등)

## #️⃣ 스크린샷 (선택)

<img width="1143" height="877" alt="Image" src="https://github.com/user-attachments/assets/335cf2d7-5397-4feb-a4f3-8ddc86b9524d" />