### PR TITLE
[feat] 회원탈퇴 구현

### DIFF
--- a/backend/database.sql
+++ b/backend/database.sql
@@ -38,7 +38,7 @@ DROP TABLE IF EXISTS special_clause;
 DROP TABLE IF EXISTS category;
 DROP TABLE IF EXISTS registry_analysis;
 DROP TABLE IF EXISTS users;
-
+SELECT * from users;
 -- ============================================
 -- 1. 사용자 관련
 -- ============================================
@@ -46,7 +46,9 @@ CREATE TABLE users (
                        user_id INT AUTO_INCREMENT PRIMARY KEY,
                        kakao_id VARCHAR(100) UNIQUE NOT NULL,
                        name VARCHAR(50) NOT NULL,
-                       role VARCHAR(50) DEFAULT 'USER'
+                       email VARCHAR(100),
+                       role VARCHAR(50) DEFAULT 'USER',
+                       state boolean DEFAULT TRUE
 );
 
 -- ============================================

--- a/backend/src/main/java/org/scoula/oauth/controller/AccessController.java
+++ b/backend/src/main/java/org/scoula/oauth/controller/AccessController.java
@@ -15,4 +15,11 @@ public class AccessController {
         return ResponseEntity.ok("AUTHORIZED");
     }
 
+
+    @GetMapping("/agreement")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> checkAgreementCheckAccess() {
+        return ResponseEntity.ok("AUTHORIZED");
+    }
+
 }

--- a/backend/src/main/java/org/scoula/oauth/controller/KakaoOAuthController.java
+++ b/backend/src/main/java/org/scoula/oauth/controller/KakaoOAuthController.java
@@ -3,6 +3,7 @@ package org.scoula.oauth.controller;
 import lombok.RequiredArgsConstructor;
 import org.scoula.oauth.domain.DTO.KakaoUserDTO;
 import org.scoula.oauth.service.KakaoOAuthService;
+import org.scoula.security.util.JwtProcessor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,6 +15,8 @@ import java.util.Map;
 public class KakaoOAuthController {
 
     private final KakaoOAuthService kakaoOAuthService;
+    private final JwtProcessor jwtProcessor;
+
     // 카카오 로그인 요청 -> access_token -> jwt 변환
     @PostMapping("/login")
     public ResponseEntity<?> kakaoLogin(@RequestBody Map<String, String> body) {
@@ -22,6 +25,25 @@ public class KakaoOAuthController {
         String accessToken = kakaoOAuthService.getAccessTokenFromKakao(code);
         // access_token을 넘겨서 전체 로그인 처리 (userInfo + DB 저장 + JWT 발급)
         String jwt = kakaoOAuthService.loginWithKakao(accessToken);
-        return ResponseEntity.ok(Map.of("jwt", jwt));
+        return ResponseEntity.ok(Map.of(
+                "jwt", jwt,
+                "kakaoAccessToken", accessToken
+        ));
+    }
+
+    @PostMapping("/unlink")
+    public ResponseEntity<?> unlink(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody Map<String, String> body
+    ) {
+        String jwt = authorizationHeader.replace("Bearer ", "");
+        String kakaoAccessToken = body.get("kakaoAccessToken");
+
+        kakaoOAuthService.unlinkKakaoAccount(kakaoAccessToken);
+
+        String kakaoId = jwtProcessor.getUsername(jwt);
+        kakaoOAuthService.softDeleteUser(kakaoId);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/org/scoula/oauth/domain/DTO/KakaoApiResponse.java
+++ b/backend/src/main/java/org/scoula/oauth/domain/DTO/KakaoApiResponse.java
@@ -12,8 +12,17 @@ public class KakaoApiResponse {
     // 추후 다른 정보 가져올 수 있으니 properties로 정의
     private Properties properties;
 
+    private KakaoAccount kakao_account;
+
     @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Properties {
         private String nickname;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoAccount {
+        private String email; // 카카오 응답 형태가 kakao_account.email
     }
 }

--- a/backend/src/main/java/org/scoula/oauth/domain/DTO/KakaoUserDTO.java
+++ b/backend/src/main/java/org/scoula/oauth/domain/DTO/KakaoUserDTO.java
@@ -2,10 +2,14 @@ package org.scoula.oauth.domain.DTO;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class KakaoUserDTO {
     private String kakaoId;
     private String name;
+    private String email;
+    private boolean state;
 }

--- a/backend/src/main/java/org/scoula/oauth/mapper/UserMapper.java
+++ b/backend/src/main/java/org/scoula/oauth/mapper/UserMapper.java
@@ -5,4 +5,6 @@ import org.scoula.oauth.domain.DTO.KakaoUserDTO;
 public interface UserMapper {
     KakaoUserDTO findByKakaoId(String kakaoId);
     void insertUser(KakaoUserDTO user);
+    void reactivateUser(String kakaoId);
+    void softDeleteUser(String kakaoId);
 }

--- a/backend/src/main/java/org/scoula/oauth/service/KakaoOAuthService.java
+++ b/backend/src/main/java/org/scoula/oauth/service/KakaoOAuthService.java
@@ -6,4 +6,6 @@ public interface KakaoOAuthService {
     String getAccessTokenFromKakao(String code);
     KakaoUserDTO requestKakaoUserInfo(String accessToken);
     String loginWithKakao(String kakaoAccessToken);
+    void softDeleteUser(String kakaoId);
+    void unlinkKakaoAccount(String accessToken);
 }

--- a/backend/src/main/java/org/scoula/oauth/service/UserService.java
+++ b/backend/src/main/java/org/scoula/oauth/service/UserService.java
@@ -18,8 +18,12 @@ public class UserService {
         if (user == null) {
             userMapper.insertUser(kakaoUser);
             return kakaoUser; // 새로 저장한 유저 반환
+        }else {
+            if (!user.isState()) {
+                // 소프트딜리트 상태 → 복구 처리
+                userMapper.reactivateUser(kakaoUser.getKakaoId());
+            }
+            return user; // 기존 유저 반환
         }
-
-        return user; // 기존 유저 반환
     }
 }

--- a/backend/src/main/resources/org/scoula/mapper/UserMapper.xml
+++ b/backend/src/main/resources/org/scoula/mapper/UserMapper.xml
@@ -5,13 +5,25 @@
 
 <mapper namespace="org.scoula.oauth.mapper.UserMapper">
     <select id="findByKakaoId" resultType="org.scoula.oauth.domain.DTO.KakaoUserDTO">
-        SELECT kakao_id AS kakaoId, name
+        SELECT kakao_id AS kakaoId, name, email, state
         FROM users
         WHERE kakao_id = #{kakaoId}
     </select>
 
     <insert id="insertUser">
-        INSERT INTO users (kakao_id, name, role)
-        VALUES (#{kakaoId}, #{name}, 'USER')
+        INSERT INTO users (kakao_id, name, email, role)
+        VALUES (#{kakaoId}, #{name}, #{email}, 'USER')
     </insert>
+
+    <update id="reactivateUser">
+        UPDATE users
+        SET state = true
+        WHERE kakao_id = #{kakaoId}
+    </update>
+
+    <update id="softDeleteUser">
+        UPDATE users
+        SET state = false
+        WHERE kakao_id = #{kakaoId}
+    </update>
 </mapper>

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -26,12 +26,12 @@ async function goToAnalysis() {
 
   try {
     //  로그인 상태라면 백엔드 권한 확인
-    await axios.get('/api/check-access/safety-check', {
+    await axios.get('/api/check-access/agreement', {
       headers: { Authorization: `Bearer ${auth.token}` },
     });
 
     // 200 OK면 진단 페이지로 이동
-    router.push('/safety-check');
+    router.push('/agreement');
   } catch (err) {
     console.error('접근 권한 없음:', err);
     router.push('/login'); // 인증 실패 시 로그인 페이지로 이동

--- a/frontend/src/pages/MyPage.vue
+++ b/frontend/src/pages/MyPage.vue
@@ -1,20 +1,207 @@
 <script setup>
 import Header from '../components/Header.vue';
 import { useAuthStore } from '@/stores/auth';
+import { onMounted, ref } from 'vue';
+import axios from 'axios';
 
 const clientId = '88a530611ac6fa5a18f5747f67b6a359';
 const redirectUri = 'http://localhost:8080/';
-
-// 임시 로그아웃 함수
 const auth = useAuthStore();
+const user = ref({ name: '', email: '', kakaoId: '' });
+// 임시 로그아웃 함수
 function onKakaoLogout() {
   auth.logout();
   const kakaoAuthUrl2 = `https://kauth.kakao.com/oauth/logout?client_id=${clientId}&logout_redirect_uri=${redirectUri}`;
   window.location.href = kakaoAuthUrl2;
 }
+onMounted(async () => {
+  if (auth.token) {
+    const res = await axios.get('/api/user/me', {
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+      },
+    });
+    user.value = res.data; // { name, email } 구조라고 가정
+  }
+});
+
+async function onWithdraw() {
+  const kakaoAccessToken = sessionStorage.getItem('kakaoAccessToken');
+  if (!kakaoAccessToken) {
+    alert('카카오 access token이 없습니다.');
+    return;
+  }
+
+  if (confirm('정말로 회원 탈퇴하시겠습니까?')) {
+    try {
+      await axios.post(
+        '/api/oauth/kakao/unlink',
+        {
+          kakaoAccessToken,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${auth.token}`,
+          },
+        }
+      );
+
+      alert('회원 탈퇴가 완료되었습니다.');
+      auth.logout();
+      sessionStorage.removeItem('kakaoAccessToken');
+      window.location.href = '/';
+    } catch (error) {
+      alert('회원 탈퇴에 실패했습니다.');
+      console.error(error);
+    }
+  }
+}
 </script>
 
 <template>
-  <h1>마이페이지</h1>
-  <button @click="onKakaoLogout" class="btn">임시 로그아웃</button>
+  <div class="mypage-container">
+    <h1 class="mypage-title">My Page</h1>
+
+    <div class="user-info">
+      <p class="user-name">{{ user.name }}</p>
+      <p class="user-email">{{ user.email }}</p>
+      <button @click="onKakaoLogout" class="btn">임시 로그아웃</button>
+      <p class="user-note">
+        모든 리포트는 생성일로부터 50일이 지나면 자동 만료됩니다.<br />
+        필요한 경우 <span class="pdf-highlight">PDF로 저장해 보관</span>하시는
+        것을 권장드립니다.
+      </p>
+    </div>
+
+    <section class="report-section section-with-button">
+      <h2>계약 리스크 분석 리포트 목록</h2>
+      <button class="more-btn" @click="goToReportPage">더보기</button>
+      <!-- table -->
+    </section>
+
+    <section class="contract-section section-with-button">
+      <h2>참고용 계약서 목록</h2>
+      <button class="more-btn" @click="goToContractPage">더보기</button>
+      <!-- table -->
+    </section>
+
+    <button class="withdraw-btn" @click="onWithdraw">회원 탈퇴</button>
+  </div>
 </template>
+
+<style scoped>
+.mypage-container {
+  padding: 40px 5vw;
+  max-width: 1000px;
+  margin: 0 auto;
+  font-family: 'Pretendard', sans-serif;
+}
+
+.mypage-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 24px;
+}
+
+.user-info {
+  margin-bottom: 32px;
+}
+
+.user-name {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.user-email {
+  font-size: 14px;
+  color: #888;
+  margin-top: 4px;
+}
+
+.user-note {
+  font-size: 13px;
+  color: #555;
+  margin-top: 10px;
+  line-height: 1.5;
+}
+
+.pdf-highlight {
+  color: #1a73e8;
+  font-weight: 500;
+}
+
+.section-with-button {
+  position: relative;
+  margin-bottom: 32px;
+}
+
+.section-with-button h2 {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.section-with-button .more-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-size: 13px;
+  padding: 4px 12px;
+  background-color: #1a73e8;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+/* 테이블 */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+thead {
+  background-color: #f8f8f8;
+}
+
+th,
+td {
+  padding: 12px;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+.withdraw-btn {
+  margin-top: 40px;
+  background: none;
+  border: 1px solid #ccc;
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+/* 반응형 대응 */
+@media (max-width: 768px) {
+  .mypage-title {
+    font-size: 22px;
+  }
+
+  .user-name {
+    font-size: 18px;
+  }
+
+  .user-note {
+    font-size: 12px;
+  }
+
+  table {
+    font-size: 12px;
+  }
+
+  .more-btn {
+    font-size: 12px;
+    padding: 4px 8px;
+  }
+}
+</style>

--- a/frontend/src/pages/login/KakaoCallback.vue
+++ b/frontend/src/pages/login/KakaoCallback.vue
@@ -18,6 +18,7 @@ if (code) {
     })
     .then((res) => {
       auth.login(res.data.jwt); // JWT 저장
+      sessionStorage.setItem('kakaoAccessToken', res.data.kakaoAccessToken); // sessionStorage에 카카오 액세스 토큰 저장 -> 회원탈퇴 시 사용
       router.replace('/'); // 홈으로 리다이렉트
     })
     .catch((err) => {

--- a/frontend/src/pages/login/LoginPage.vue
+++ b/frontend/src/pages/login/LoginPage.vue
@@ -33,10 +33,20 @@ function goToMain() {
   justify-content: center;
   height: 100vh;
   font-family: 'Pretendard', sans-serif;
+  padding: 20px;
+  max-width: 100%;
 }
 .logo {
-  width: 200px;
+  width: 646px;
+  max-width: 90vw;
+  height: auto;
   margin-bottom: 20px;
+}
+.login-container p {
+  font-size: 26px;
+  max-width: 1042px;
+  text-align: center;
+  margin-bottom: 30px;
 }
 .highlight {
   color: #007bff;
@@ -45,17 +55,37 @@ function goToMain() {
 .kakao-btn {
   background-color: #fee500;
   border: none;
-  padding: 12px 24px;
-  font-weight: bold;
-  font-size: 16px;
+  padding: 0;
+  width: 453px;
+  height: 86px;
   border-radius: 10px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+}
+.kakao-btn img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 .skip {
   margin-top: 10px;
   color: gray;
   font-size: 12px;
+}
+
+/* 반응형 처리 */
+@media (max-width: 768px) {
+  .logo {
+    width: 60vw;
+  }
+  .login-container p {
+    font-size: 18px;
+    max-width: 90vw;
+  }
+  .kakao-btn {
+    width: 80vw;
+    height: 60px;
+  }
 }
 </style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -49,6 +49,7 @@ const routes = [
     name: 'AgreementPage',
     component: AgreementPage,
     meta: { hideHeader: true },
+    meta: { requiresAuth: true },
   },
   {
     path: '/reference-contract',
@@ -61,7 +62,7 @@ const routes = [
     component: GuidebookPage,
   },
   { path: '/glossary', name: 'glossary', component: GlossaryBook },
-  { path: '/my', name: 'my', component: MyPage },
+  { path: '/my', name: 'my', component: MyPage, meta: { requiresAuth: true } },
   {
     path: '/checklist/nondiagnosis',
     name: 'nondiagnosis',


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #108

## #️⃣ 작업 내용

> 마이페이지에서 회원탈퇴 버튼 클릭시 회원탈퇴 기능 구현 -> db상에는 state 컬럼으로 소프트딜리트 구현
 회원탈퇴시 카카오 액세스 토큰이 필요하여 세션스토리지에 카카오액세스 토큰 저장 -> XSS 위협이 로컬스토리지보단 덜 위험하지만 아직 XSS 위험 존재함 -> 추후에 refresh 토큰 구현하여 쿠키에 저장하면 해결 하지만 구현에 시간이 오래 걸릴거같아 추후에 개발

## #️⃣ 테스트 결과

> 작동 완료
## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
