### PR TITLE
feat: 전세가율 분석 기능 - 매물 조회 시 필터링 조건에 건물명추가

### DIFF
--- a/backend/src/main/java/org/scoula/jeonseRate/controller/LeaseDiagnosisController.java
+++ b/backend/src/main/java/org/scoula/jeonseRate/controller/LeaseDiagnosisController.java
@@ -49,11 +49,14 @@ public class LeaseDiagnosisController {
         // 4. 지번 주소 (예: 595-28)
         String jibun  = addressInfo.getJibunAddr();
 
+        // 5. 건물명
+        String buildingName = addressInfo.getBdNm();
+
 //        System.out.println("[요청] 주소: " + request.getAddress() + ", 보증금: " + request.getJeonsePrice());
 
         // 5. 해당 주소에 대한 매매가 평균 조회
         Optional<JeonseRateDTO> averageDealPriceOpt = dealSearchService.getDealAmount(
-                lawdCode, jibun , recentMonths
+                lawdCode, jibun, buildingName, recentMonths
         );
         // 조회된 매물이 없을 경우 메시지 반환
         if (averageDealPriceOpt.isEmpty()) {
@@ -112,18 +115,6 @@ public class LeaseDiagnosisController {
 
         jeonseAnalysisMapper.insertJeonseAnalysis(vo);
 
-        // 10. 응답 반환(테스트용)
-//        Map<String, Object> result = new HashMap<>();
-//        result.put("admCd", addressInfo.getAdmCd());            // 법정동 코드
-//        result.put("jibunAddr", addressInfo.getJibunAddr());    // 지번 주소
-//        result.put("jeonsePrice", jeonse);                      // 입력 전세 보증금
-//        result.put("expectedSalePrice", (int) averageDealPrice);// 예상 매매가
-//        result.put("jeonseRate", roundedJeonseRate);            // 전세가율 (%)
-//        result.put("avgKosisRate", Math.round(avgKosisRate * 10.0) / 10.0);
-//        result.put("deviation", deviation);
-//        result.put("grade", grade.name()); // 문자열로 변환
-
-//        System.out.println(result);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/org/scoula/jeonseRate/dto/AddressInfoDTO.java
+++ b/backend/src/main/java/org/scoula/jeonseRate/dto/AddressInfoDTO.java
@@ -14,5 +14,6 @@ public class AddressInfoDTO {
     private String admCd;       // 법정동 코드
     private String jibunAddr;   // 지번 주소
     private String siNm;        // 시도명
+    private String bdNm;        // 건물명
     //private String sggNm;       // 구명
 }

--- a/backend/src/main/java/org/scoula/jeonseRate/service/AddressService.java
+++ b/backend/src/main/java/org/scoula/jeonseRate/service/AddressService.java
@@ -52,6 +52,7 @@ public class AddressService {
         String admCd = json.getString("admCd");       // 법정동 코드
         String lnbrMnnm = json.getString("lnbrMnnm"); // 지번 본번 (예: "595")
         String lnbrSlno = json.getString("lnbrSlno"); // 지번 부번 (예: "28")
+        String bdNm = json.optString("bdNm", "");  // 건물명 (없으면 빈 문자열)
 
         // 부번이 0이면 생략, 아니면 "본번-부번" 형태로 조합
         String jibun = lnbrSlno.equals("0") ? lnbrMnnm : lnbrMnnm + "-" + lnbrSlno;
@@ -59,6 +60,7 @@ public class AddressService {
         //String sggNm = json.getString("sggNm");
         String siNm = json.getString("siNm");
 
-        return new AddressInfoDTO(admCd, jibun, siNm);
+        return new AddressInfoDTO(admCd, jibun, siNm, bdNm);
+//        return new AddressInfoDTO(admCd, jibun, siNm);
     }
 }

--- a/backend/src/main/java/org/scoula/jeonseRate/service/DealSearchService.java
+++ b/backend/src/main/java/org/scoula/jeonseRate/service/DealSearchService.java
@@ -47,7 +47,7 @@ public class DealSearchService {
      * @param recentMonths 조회 대상 월 목록
      * @return 유사 매물 평균 매매가 (단위: 만원)
      */
-    public Optional<JeonseRateDTO> getDealAmount(String lawdCode, String jibun , List<String> recentMonths) {
+    public Optional<JeonseRateDTO> getDealAmount(String lawdCode, String jibun ,String buildingName, List<String> recentMonths) {
         JeonseRateDTO jeonseRateDTO = new JeonseRateDTO();
         List<DealDTO> allDeals = new ArrayList<>();
 
@@ -84,25 +84,44 @@ public class DealSearchService {
 
         // 모든 유형에서 매물이 없다면 판단 보류
         if (allDeals.isEmpty()) {
-//            System.out.println("모든 유형에서 실거래 매물 없음 → 판단 보류");
             return Optional.empty();
         }
 
-        // 지번과 같은 매물 필터링
-        List<DealDTO> filtered = allDeals.stream()
+        // 1차 필터: 지번 기준
+        List<DealDTO> filteredByJibun = allDeals.stream()
                 .filter(d -> d.getJibun() != null && d.getJibun().equals(jibun))
                 .collect(Collectors.toList());
 
-//        System.out.println("📌 [매매가 조회] 검색 지번: " + jibun + ", 조회 매물 수: " + allDeals.size());
+        // 2차 필터: 건물명 기준 (있을 경우만)
+        List<DealDTO> finalFiltered = filteredByJibun.stream()
+                .filter(d -> {
+                    if (buildingName == null || buildingName.isBlank()) return true;
+
+                    return isSimilarName(buildingName, d.getAptNm()) ||
+                            isSimilarName(buildingName, d.getOffiNm()) ||
+                            isSimilarName(buildingName, d.getMhouseNm());
+                })
+                .collect(Collectors.toList());
+
+        // 로그 찍기
+//        System.out.println("입력 건물명: " + buildingName);
+//        System.out.println("필터링 전 매물 수: " + allDeals.size());
+//        System.out.println("지번 필터링 수: " + filteredByJibun.size());
+//        System.out.println("건물명 필터링 최종 수: " + finalFiltered.size());
+//
+//        System.out.println("=== 최종 필터링된 매물 목록 ===");
+//        finalFiltered.forEach(d ->
+//                System.out.println("지번: " + d.getJibun() + ", 아파트명: " + d.getAptNm() + ", 오피스텔명: " + d.getOffiNm() + ", 연립명: " + d.getMhouseNm())
+//        );
+
 
         // 매물이 없다면 판단 보류
-        if (filtered.isEmpty()) {
-//            System.out.println("같은 지번 매물 없음 → 판단 보류");
+        if (finalFiltered.isEmpty()) {
             return Optional.empty();
         }
 
         // 평균 매매가 계산 (단위: 만원)
-        double avg = filtered.stream()
+        double avg = finalFiltered.stream()
                 .mapToDouble(d -> Double.parseDouble(d.getDealAmount().replace(",", "")))
                 .average()
                 .orElse(0);
@@ -112,6 +131,20 @@ public class DealSearchService {
 
         //System.out.println("유사 조건 매물 평균 매매가: " + roundedAvg + "만원");
         return Optional.of(jeonseRateDTO);
+    }
+
+    private String normalize(String name) {
+        if (name == null) return "";
+        return name.replaceAll("\\s+", "")                            // 모든 공백 제거
+                .replaceAll("(아파트|오피스텔|연립|주상복합)", "") // 건물유형 제거
+                .toLowerCase();                                    // (선택) 소문자 통일
+    }
+
+    private boolean isSimilarName(String input, String target) {
+        if (input == null || target == null) return false;
+        String normalizedInput = normalize(input);
+        String normalizedTarget = normalize(target);
+        return normalizedInput.contains(normalizedTarget) || normalizedTarget.contains(normalizedInput);
     }
 
     /**
@@ -124,12 +157,10 @@ public class DealSearchService {
                     dto.getResponse().getBody() == null ||
                     dto.getResponse().getBody().getItems() == null ||
                     dto.getResponse().getBody().getItems().getItem() == null) {
-                //System.out.println("실거래 응답에서 items가 비어 있음 → 빈 리스트 반환");
                 return List.of();
             }
             return dto.getResponse().getBody().getItems().getItem();
         } catch (Exception e) {
-//            System.out.println("응답 파싱 실패 → 빈 리스트 반환");
             return List.of();
         }
     }
@@ -154,8 +185,6 @@ public class DealSearchService {
                 .retrieve()
                 .bodyToMono(String.class)   // 응답 본문을 문자열로 받음
                 .block();
-
-//        System.out.println("매물->" + response);
 
         try {
             return objectMapper.readValue(response, DealResponseDTO.class);

--- a/frontend/src/pages/RegisterResult.vue
+++ b/frontend/src/pages/RegisterResult.vue
@@ -72,7 +72,13 @@
         >
           <p class="fw-bold fs-5 mb-2" style="color: #151fae">기본 정보</p>
           <h4>주소: {{ result.address }}</h4>
-          <h4>예상 전세가율: {{ result.jeonseRate }} %</h4>
+          <h4>
+            예상 전세가율:
+            <span v-if="result.jeonseRate !== -1"
+              >{{ result.jeonseRate }} %</span
+            >
+            <span v-else style="color: gray">판단 불가</span>
+          </h4>
           <div style="flex: 1; overflow-y: auto; margin-top: 1rem">
             <AnalysisCards
               v-if="result && result.analysis"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #118 

## #️⃣ 작업 내용

기존에는 법정동 + 지번으로만 같은 매물을 조회했음
추가된 기능 : 건물명 필터링

같은 지번에 다른 건물도 있기 때문에 건물명도 필터링하는 기능을 추가하여 조금 더 정확도를 높임
주소 API에서 건물명도 추출하고 추출된 건물명을 국토부 api에서 조회된 매물에서 필터링함.
만약 조회된 매물에서 건물명 표기가 안 되어 있으면 지번으로만 필터링

프론트 뷰에서 -1은 판단보류라고 뜨게 변경

## #️⃣ 테스트 결과

<img width="512" height="317" alt="image" src="https://github.com/user-attachments/assets/4fa7e12c-6a6e-4ae0-97e1-df88939ff33a" />

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?


