### PR TITLE
[feat] 최종 리포트 백엔드와 연동(등급, 전세가율, 체크리스트)

### DIFF
--- a/frontend/src/components/final-report/FinalChecklist.vue
+++ b/frontend/src/components/final-report/FinalChecklist.vue
@@ -18,7 +18,7 @@ const uncheckedItems = computed(() => {
       :key="index"
       class="checkedlist-box p-3 rounded mb-3 text-start"
     >
-      <p class="mb-0">{{ item }}</p>
+      <p class="mb-0" v-html="item"></p>
     </div>
   </div>
 </template>

--- a/frontend/src/pages/FinalReportPage.vue
+++ b/frontend/src/pages/FinalReportPage.vue
@@ -12,17 +12,17 @@ import FinalJeonseCard from '@/components/final-report/FinalJeonseCard.vue';
 import checklistStore from '@/stores/checklistStore';
 
 const route = useRoute();
-// const reportData = ref(null);
 const showModal = ref(false);
-
 const openModal = () => {
   showModal.value = true;
 };
 const closeModal = () => {
   showModal.value = false;
 };
-
 const { goToHome, goToMyPage } = useNavigation();
+
+const reportId = 1;
+const reportData = ref(null);
 
 // 쿼리 파라미터 기반 (만약 path param 방식이면 수정하기)
 // const registryId = Number(route.query.registryId);
@@ -34,34 +34,35 @@ const { goToHome, goToMyPage } = useNavigation();
 //   }
 // });
 
-// 임시 목 데이터
-const reportId = 1;
-const reportData = ref({
-  registryRating: '보통',
-  jeonseRatioRating: '위험',
-  checklistRating: '안전',
-  jeonseRatio: 80,
-  regionAvgJeonseRatio: 75.0,
-  jeonseDeposit: 28000, // 만원 단위
-  salePrice: 36000,
-  username: '버디',
-  checked: [true, true, false, true, false, true, true, true, false],
-  // checked: [true, true, true, true, true, true, true, true, true],
+onMounted(async () => {
+  const res = await getFinalReport(reportId);
+  reportData.value = {
+    registryRating: res?.registryRating ?? '',
+    jeonseRatioRating: res?.jeonseRatioRating ?? '',
+    checklistRating: res?.checklistRating ?? '',
+    jeonseRatio: res?.jeonseRatio ?? 0,
+    regionAvgJeonseRatio: res?.regionAvgJeonseRatio ?? 0,
+    expectedSellingPrice: res?.expectedSellingPrice ?? 0,
+    deposit: res?.deposit ?? 0,
+    username: res?.username ?? '사용자',
+    checked: res?.checked ?? [],
+  };
 });
 
-//   const res = await getFinalReport(reportId);
-//   // 안전하게 받아온 데이터가 없으면 기본값 할당
-//   reportData.value = {
-//     registryRating: res?.registryRating ?? '',
-//     jeonseRatioRating: res?.jeonseRatioRating ?? '',
-//     checklistRating: res?.checklistRating ?? '',
-//     jeonseRatio: res?.jeonseRatio ?? 0,
-//     regionAvgJeonseRatio: res?.regionAvgJeonseRatio ?? 0,
-//     salePrice: res?.salePrice ?? 0,
-//     jeonseDeposit: res?.jeonseDeposit ?? 0,
-//     username: res?.username ?? '사용자',
-//     checked: res?.checked ?? []
-//   };
+// 임시 목 데이터
+// const reportId = 1;
+// const reportData = ref({
+//   registryRating: '보통',
+//   jeonseRatioRating: '위험',
+//   checklistRating: '안전',
+//   jeonseRatio: 80,
+//   regionAvgJeonseRatio: 75.0,
+//   jeonseDeposit: 28000, // 만원 단위
+//   salePrice: 36000,
+//   username: '버디',
+//   checked: [true, true, false, true, false, true, true, true, false],
+//   // checked: [true, true, true, true, true, true, true, true, true],
+// });
 
 const uncheckedItems = computed(() => {
   return checklistStore.filter(
@@ -71,7 +72,7 @@ const uncheckedItems = computed(() => {
 </script>
 
 <template>
-  <div class="FinalReportPage container py-5 text-center">
+  <div class="FinalReportPage container py-5 text-center" v-if="reportData">
     <h1>최종 분석이 완료되었어요.</h1>
     <p class="text-muted">
       모든 등급은
@@ -118,8 +119,8 @@ const uncheckedItems = computed(() => {
           <div class="final-jeonse-col">
             <FinalJeonseCard
               v-if="reportData"
-              :salePrice="reportData.salePrice"
-              :jeonseDeposit="reportData.jeonseDeposit"
+              :salePrice="reportData.expectedSellingPrice"
+              :jeonseDeposit="reportData.deposit"
               :jeonseRatio="reportData.jeonseRatio"
               :jeonseRatioRating="reportData.jeonseRatioRating"
               :username="reportData.username"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #133 

## #️⃣ 작업 내용

- [x] FinalreportPage에서 주석처리해놨던 연동 코드 주석 해제
- [x] reportData.value가 아직 null인 상태에서 템플릿이 먼저 렌더링되지 않도록 v-if="reportData" 추가
- [x] 체크리스트 항목 태그 출력 이슈 해결을 위해 v-html로 변경
- [x] 백엔드와 변수명 일치하도록 수정

## #️⃣ 스크린샷 (선택)

<img width="851" height="443" alt="Image" src="https://github.com/user-attachments/assets/9b4b60a6-5ee5-470d-8a67-28a8fdba394a" />

<img width="887" height="424" alt="Image" src="https://github.com/user-attachments/assets/9f27e1dd-24ce-425f-90dc-4c7456395afb" />

<img width="1010" height="483" alt="Image" src="https://github.com/user-attachments/assets/5f400bdc-be73-4de0-a8da-07b0c1126d71" />

