### PR TITLE
[feat] 최종리포트 생성일로부터 50일 후 만료 구현

### DIFF
--- a/backend/src/main/java/org/scoula/config/RootConfig.java
+++ b/backend/src/main/java/org/scoula/config/RootConfig.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import javax.sql.DataSource;
@@ -35,6 +36,7 @@ import javax.sql.DataSource;
 })
 @ComponentScan(basePackages = {"org.scoula", "org.scoula.oauth.service"})
 @EnableTransactionManagement
+@EnableScheduling
 @Log4j2
 public class RootConfig {
     @Value("${jdbc.driver}") String driver;

--- a/backend/src/main/java/org/scoula/finalreport/mapper/FinalReportMapper.java
+++ b/backend/src/main/java/org/scoula/finalreport/mapper/FinalReportMapper.java
@@ -15,8 +15,9 @@ public interface FinalReportMapper {
     Long findReportIdByUserAndRegistry(@Param("userId") Long userId, @Param("registryId") Long registryId);
 
     // userId, registryId 저장
-//    void insertFinalReport(@Param("userId") Long userId, @Param("registryId") Long registryId);
     void insertFinalReport(FinalReportInsertDTO dto);
 
+    // 50일이 지난 리포트의 status를 false로 변경하고, 변경된 레코드 수를 반환
+    int expireOldReports();
 
 }

--- a/backend/src/main/java/org/scoula/finalreport/scheduler/FinalReportScheduler.java
+++ b/backend/src/main/java/org/scoula/finalreport/scheduler/FinalReportScheduler.java
@@ -1,0 +1,23 @@
+package org.scoula.finalreport.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.scoula.finalreport.mapper.FinalReportMapper;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class FinalReportScheduler {
+
+    private final FinalReportMapper finalReportMapper;
+
+    // 테스트용 (1분마다 돌아가게하기)
+   //  @Scheduled(cron = "0 */1 * * * *")
+     @Scheduled(cron = "0 0 3 * * *") // 사용자, 개발자 모두 잘 접속하지 않는 새벽 3시로 설정
+    public void expireFinalReports() {
+        int updated = finalReportMapper.expireOldReports();
+        log.info("리포트 " + updated + "건이 자동 만료되었습니다.");
+    }
+}

--- a/backend/src/main/resources/org/scoula/finalreport/mapper/FinalReportMapper.xml
+++ b/backend/src/main/resources/org/scoula/finalreport/mapper/FinalReportMapper.xml
@@ -42,4 +42,14 @@
         INSERT INTO final_report (user_id, registry_id)
         VALUES (#{userId}, #{registryId});
     </insert>
+
+    <!--  50일 후 레포트 만료   -->
+    <update id="expireOldReports">
+    <![CDATA[
+        UPDATE final_report
+        SET status = FALSE
+        WHERE created_at < NOW() - INTERVAL 50 DAY
+          AND status = TRUE
+        ]]>
+    </update>
 </mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #151 

## #️⃣ 작업 내용

- [ ] RootConfig - @EnableScheduling 추가
- [ ] FinalReportScheduler.java
- [ ] FinalReportMapper.java
- [ ] FinalReportMapper.xml

## #️⃣ 테스트 결과

> 60일 이전 데이터 넣어서 테스트 완료

<img width="920" height="139" alt="Image" src="https://github.com/user-attachments/assets/81d58774-a5e1-420f-93a3-b252adaa70ff" />

<img width="906" height="132" alt="Image" src="https://github.com/user-attachments/assets/2d9e7b53-08d8-482c-b08c-1c0f38084b47" />
