### PR TITLE
[feat] 최종 리포트 registryId, userId DB 저장 프론트 로직 추가

### DIFF
--- a/frontend/src/pages/FinalReportPage.vue
+++ b/frontend/src/pages/FinalReportPage.vue
@@ -35,33 +35,36 @@ console.log('넘어온 userId:', userId);
 console.log('넘어온 registryId:', registryId);
 
 onMounted(async () => {
-  // 테스트용 코드
-  console.log('쿼리 파라미터:', route.query);
-  console.log('userId:', route.query.userId);
-  console.log('registryId:', route.query.registryId);
-
   if (!userId || !registryId || isNaN(userId) || isNaN(registryId)) {
     console.warn('잘못된 쿼리 파라미터');
     return;
   }
-});
 
-onMounted(async () => {
-  // const res = await getFinalReport(reportId);
-  const res = await getFinalReportByUserAndRegistry(userId, registryId);
+  try {
+    // final_report에 저장
+    await fetch(`/api/reports?userId=${userId}&registryId=${registryId}`, {
+      method: 'POST',
+    });
 
-  reportData.value = {
-    registryRating: res?.registryRating ?? '',
-    registryAnalysis: res?.registryAnalysis ?? null,
-    jeonseRatioRating: res?.jeonseRatioRating ?? '',
-    checklistRating: res?.checklistRating ?? '',
-    jeonseRatio: res?.jeonseRatio ?? 0,
-    regionAvgJeonseRatio: res?.regionAvgJeonseRatio ?? 0,
-    expectedSellingPrice: res?.expectedSellingPrice ?? 0,
-    deposit: res?.deposit ?? 0,
-    username: res?.username ?? '사용자',
-    checked: res?.checked ?? [],
-  };
+    // report 조회
+    const res = await getFinalReportByUserAndRegistry(userId, registryId);
+
+    // 데이터 바인딩
+    reportData.value = {
+      registryRating: res?.registryRating ?? '',
+      registryAnalysis: res?.registryAnalysis ?? null,
+      jeonseRatioRating: res?.jeonseRatioRating ?? '',
+      checklistRating: res?.checklistRating ?? '',
+      jeonseRatio: res?.jeonseRatio ?? 0,
+      regionAvgJeonseRatio: res?.regionAvgJeonseRatio ?? 0,
+      expectedSellingPrice: res?.expectedSellingPrice ?? 0,
+      deposit: res?.deposit ?? 0,
+      username: res?.username ?? '사용자',
+      checked: res?.checked ?? [],
+    };
+  } catch (error) {
+    console.error('최종 리포트 생성 또는 조회 실패:', error);
+  }
 });
 
 const uncheckedItems = computed(() => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #155

## #️⃣ 작업 내용

- [x] FinalReportPage.vue에서 onMounted() 시점에 POST /api/reports?userId= &registryId= 요청 추가

## #️⃣ 테스트 결과

> 테스트 url
http://localhost:5173/final-report?userId=1&registryId=2
http://localhost:5173/final-report?userId=1&registryId=1

<img width="752" height="69" alt="Image" src="https://github.com/user-attachments/assets/6b327079-4b72-4317-afbf-5764fa111853" />