### PR TITLE
[style] 최종 리포트 전세가율 카드 스타일 개선

### DIFF
--- a/frontend/src/components/final-report/FinalJeonseCard.vue
+++ b/frontend/src/components/final-report/FinalJeonseCard.vue
@@ -16,16 +16,25 @@ const gradeColorStyle = computed(() => getGradeColor(props.jeonseRatioRating));
 <template>
   <div class="FinalJeonseCard">
     <div
-      class="rounded-3 shadow-sm mx-auto pt-3 pb-2"
-      style="max-width: 400px; background-color: #f8f9fa"
+      class="rounded-3 shadow-sm mx-auto pt-3 pb-3"
+      style="max-width: 640px; width: 100%; background-color: #f8f9fa"
     >
-      <div class="jeonse-card-wrap px-5 mx-5 text-start">
-        <p>예상 매매가 : {{ (salePrice || 0).toLocaleString() }}만원</p>
-        <p>전세 보증금 : {{ (jeonseDeposit || 0).toLocaleString() }}만원</p>
-        <p>예상 전세가율 : {{ (jeonseRatio || 0).toLocaleString() }}%</p>
+      <div class="px-4 text-start">
+        <p class="mb-0 fs-6 fw-semibold">
+          예상 매매가 : {{ (salePrice || 0).toLocaleString() }}만원
+        </p>
+        <p class="mb-0 fs-6 fw-semibold">
+          전세 보증금 : {{ (jeonseDeposit || 0).toLocaleString() }}만원
+        </p>
+        <p class="mb-0 fs-6 fw-semibold">
+          예상 전세가율 : {{ (jeonseRatio || 0).toLocaleString() }}%
+        </p>
       </div>
     </div>
-    <h5 class="mt-5">
+    <h5
+      class="mt-4 text-center fs-5 fw-normal text-nowrap"
+      style="max-width: 640px; margin: 0 auto"
+    >
       <span>{{ username }}님의 전세가율은 </span>
       <span
         ><span class="fw-bold" :style="{ color: gradeColorStyle }"
@@ -37,6 +46,10 @@ const gradeColorStyle = computed(() => getGradeColor(props.jeonseRatioRating));
 </template>
 
 <style scoped>
-/* .FinalJeonseCard {
-} */
+@media (max-width: 576px) {
+  .FinalJeonseCard h5 {
+    white-space: normal;
+    max-width: 100% !important;
+  }
+}
 </style>

--- a/frontend/src/pages/FinalReportPage.vue
+++ b/frontend/src/pages/FinalReportPage.vue
@@ -19,7 +19,7 @@ import jsPDF from 'jspdf';
 const route = useRoute();
 const showModal = ref(false);
 const reportData = ref(null);
-const isLoadingPDF = ref(false); // ✅ 로딩 상태 추가
+const isLoadingPDF = ref(false); // 로딩 상태 추가
 
 const openModal = () => (showModal.value = true);
 const closeModal = () => (showModal.value = false);
@@ -213,7 +213,7 @@ onMounted(async () => {
                 :regionAvgJeonseRatio="reportData.regionAvgJeonseRatio"
               />
             </div>
-            <div class="final-jeonse-col" style="margin-left: 4rem">
+            <div class="final-jeonse-col ms-md-4 mt-4 mt-md-0">
               <FinalJeonseCard
                 :salePrice="reportData.expectedSellingPrice"
                 :jeonseDeposit="reportData.deposit"
@@ -399,6 +399,12 @@ onMounted(async () => {
 
   .mobile-only-break {
     display: block;
+  }
+}
+
+@media (max-width: 576px) {
+  .jeonse-card-wrap p {
+    white-space: normal;
   }
 }
 </style>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #218

## #️⃣ 작업 내용

- [x] 최종 리포트 전세가율 카드 스타일 수정

## #️⃣ 스크린샷 (선택)

<img width="807" height="455" alt="Image" src="https://github.com/user-attachments/assets/60ebbcb9-6207-49aa-827f-d9bbc8e0601f" />