### PR TITLE
[style] 전세가율 카드 스타일 수정

### DIFF
--- a/frontend/src/components/final-report/FinalJeonseCard.vue
+++ b/frontend/src/components/final-report/FinalJeonseCard.vue
@@ -14,19 +14,19 @@ const gradeColorStyle = computed(() => getGradeColor(props.jeonseRatioRating));
 </script>
 
 <template>
-  <div class="FinalJeonseCard">
+  <div class="FinalJeonseCard h-100">
     <div
-      class="rounded-3 shadow-sm mx-auto pt-3 pb-3"
-      style="max-width: 640px; width: 100%; background-color: #f8f9fa"
+      class="rounded-3 shadow-sm mx-auto d-flex flex-column justify-content-center py-4 px-4 bg-light w-100"
+      style="max-width: 640px"
     >
-      <div class="px-4 text-start">
-        <p class="mb-0 fs-6 fw-semibold">
+      <div class="text-start">
+        <p class="mb-2 fs-6 fw-semibold lh-lg">
           예상 매매가 : {{ (salePrice || 0).toLocaleString() }}만원
         </p>
-        <p class="mb-0 fs-6 fw-semibold">
+        <p class="mb-2 fs-6 fw-semibold lh-lg">
           전세 보증금 : {{ (jeonseDeposit || 0).toLocaleString() }}만원
         </p>
-        <p class="mb-0 fs-6 fw-semibold">
+        <p class="mb-2 fs-6 fw-semibold lh-lg">
           예상 전세가율 : {{ (jeonseRatio || 0).toLocaleString() }}%
         </p>
       </div>

--- a/frontend/src/pages/FinalReportPage.vue
+++ b/frontend/src/pages/FinalReportPage.vue
@@ -207,20 +207,24 @@ onMounted(async () => {
             class="d-flex flex-column flex-md-row justify-content-center align-items-end"
             style="max-width: 960px; margin: 0 auto; height: auto"
           >
-            <div class="final-jeonse-col" style="width: 100%; max-width: 480px">
-              <FinalJeonse
-                :jeonseRatio="reportData.jeonseRatio"
-                :regionAvgJeonseRatio="reportData.regionAvgJeonseRatio"
-              />
+            <div class="final-jeonse-col w-100" style="max-width: 480px">
+              <div class="h-100 d-flex align-items-end">
+                <FinalJeonse
+                  :jeonseRatio="reportData.jeonseRatio"
+                  :regionAvgJeonseRatio="reportData.regionAvgJeonseRatio"
+                />
+              </div>
             </div>
-            <div class="final-jeonse-col ms-md-4 mt-4 mt-md-0">
-              <FinalJeonseCard
-                :salePrice="reportData.expectedSellingPrice"
-                :jeonseDeposit="reportData.deposit"
-                :jeonseRatio="reportData.jeonseRatio"
-                :jeonseRatioRating="reportData.jeonseRatioRating"
-                :username="reportData.username"
-              />
+            <div class="final-jeonse-col w-100" style="max-width: 480px">
+              <div class="d-flex h-100">
+                <FinalJeonseCard
+                  :salePrice="reportData.expectedSellingPrice"
+                  :jeonseDeposit="reportData.deposit"
+                  :jeonseRatio="reportData.jeonseRatio"
+                  :jeonseRatioRating="reportData.jeonseRatioRating"
+                  :username="reportData.username"
+                />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #243 

## #️⃣ 작업 내용

- [ ] 전세가율 카드 높이, 텍스트 간격 수정

## #️⃣ 스크린샷 (선택)

<img width="873" height="454" alt="Image" src="https://github.com/user-attachments/assets/c74f81a8-13c8-442d-bfc7-30640a29bb3d" />
