### PR TITLE
[fix] 등기부등본 내 면적 추출 수정 및 체크리스트 모달 버튼 색 수정

### DIFF
--- a/backend/src/main/java/org/scoula/register/controller/TabulaController.java
+++ b/backend/src/main/java/org/scoula/register/controller/TabulaController.java
@@ -64,6 +64,7 @@ public class TabulaController {
 
             // 면적 추출
             String area = RegisterUtils.getArea(table, detail);
+//            System.out.println("면적 값: " + area);
             int registerId = tabulaService.saveAnalysis(userId, address, response, registryName, registryRating, uploadedFileName, totalPriorAmount);
 
             Map<String, Object> result = new HashMap<>();

--- a/backend/src/main/java/org/scoula/register/util/RegisterUtils.java
+++ b/backend/src/main/java/org/scoula/register/util/RegisterUtils.java
@@ -225,8 +225,8 @@ public class RegisterUtils {
 
         for (List<String> row : tableData) {
             if (row.size() < 4) continue;
-            String buildingNumber = normalizeText(row.get(2)); // 제1층 제디디01-0101호
-            String buildingDetails = normalizeText(row.get(3)); // 철근콘크리트구조 40.87㎡
+            String buildingNumber = normalizeText(row.get(2));
+            String buildingDetails = normalizeText(row.get(3));
 
             // 건물번호에 층 정보(제1층 or 1층)가 포함되어 있는지 확인
             if (buildingNumber.contains(floor) || buildingNumber.contains("제" + floor)) {

--- a/backend/src/main/java/org/scoula/register/util/RegisterUtils.java
+++ b/backend/src/main/java/org/scoula/register/util/RegisterUtils.java
@@ -223,20 +223,18 @@ public class RegisterUtils {
         String floor = detailInfo.get("층");
 //        System.out.println("층 정보: " + floor);
 
-        Pattern pattern = Pattern.compile("((지하)?\\d+층)\\s*(\\d+(?:\\.\\d+)?)m2?");
-
         for (List<String> row : tableData) {
             if (row.size() < 4) continue;
-            String buildingDetails = normalizeText(row.get(3));
-//            System.out.println("불러오는 데이터: " + buildingDetails);
+            String buildingNumber = normalizeText(row.get(2)); // 제1층 제디디01-0101호
+            String buildingDetails = normalizeText(row.get(3)); // 철근콘크리트구조 40.87㎡
 
-            Matcher matcher = pattern.matcher(buildingDetails);
-            while (matcher.find()) {
-                String foundFloor = matcher.group(1); // ex: 3층
-                String area = matcher.group(3);       // ex: 630.44
-
-                if (foundFloor.equals(floor)) {
-                    return area; // 면적 반환
+            // 건물번호에 층 정보(제1층 or 1층)가 포함되어 있는지 확인
+            if (buildingNumber.contains(floor) || buildingNumber.contains("제" + floor)) {
+                // 면적 추출
+                Pattern pattern = Pattern.compile("(\\d+(?:\\.\\d+)?)m2?");
+                Matcher matcher = pattern.matcher(buildingDetails);
+                if (matcher.find()) {
+                    return matcher.group(1); // 면적 값만 반환
                 }
             }
         }

--- a/frontend/src/pages/RegisterResult.vue
+++ b/frontend/src/pages/RegisterResult.vue
@@ -528,9 +528,9 @@ onMounted(async () => {
   gap: 16px;
 }
 
-/* 확인 버튼 */
+/* 예 버튼 */
 .confirm-button {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
   color: white;
   border: none;
   padding: 12px 24px;
@@ -543,14 +543,14 @@ onMounted(async () => {
 }
 
 .confirm-button:hover {
-  background: linear-gradient(135deg, #059669 0%, #047857 100%);
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
 }
 
-/* 취소 버튼 */
+/* 아니오 버튼 */
 .cancel-button {
-  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
   color: white;
   border: none;
   padding: 12px 24px;
@@ -563,11 +563,12 @@ onMounted(async () => {
 }
 
 .cancel-button:hover {
-  background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+  background: linear-gradient(135deg, #6b7280 0%, #4b5563 100%);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.3);
 }
 
+/* 버튼 폭 동일 */
 .confirm-button,
 .cancel-button {
   width: 100%;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호
- close #245 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
- 면적 값을 불러오는 게 잘못됐어서 수정했습니다.
- 체크리스트 넘어가기 눌렀을 때 나오는 버튼의 색을 변경했습니다.
<img width="483" height="277" alt="image" src="https://github.com/user-attachments/assets/5e8a3def-80b7-4828-bafa-0f13f0c37d12" />

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등
- 면적 값이 잘 불러와지며 전세가율이 계산되는 매물들은 계산되는 것을 확인했습니다.

## #️⃣ 변경 사항 체크리스트

- [X] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [X] 코드 컨벤션에 따라 코드를 작성했나요?
- [X] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
